### PR TITLE
fix(config): modify showlabels layouts

### DIFF
--- a/documents/config/layouts/develop.sty
+++ b/documents/config/layouts/develop.sty
@@ -36,7 +36,8 @@
 
 % ラベルを表示する
 \usepackage[inline]{showlabels}
-\renewcommand{\showlabelfont}{\small\ttfamily\color{orange}}
+\renewcommand{\showlabelfont}{\small\ttfamily\color{darkcyan}}
 \renewcommand{\showlabelsetlabel}[1]{\leftline{\showlabelfont #1}}
+\renewcommand{\showlabelrefline}{\hrule width 0pt height 2.1ex depth 0pt}
 % \showlabels{cref}
 \showlabels{cite}


### PR DESCRIPTION
Fix #13 .

<img width="677" alt="Screenshot 2021-08-22 18 47 32" src="https://user-images.githubusercontent.com/60519062/130350608-e56467a7-7872-4386-84a4-42108cdb2ec4.png">


↑こんな感じで

- 色
- 配置
- 左の線

などのレイアウトを調整.