### PR TITLE
fix(extopy): with_stem() の使用を止める

### DIFF
--- a/tools/extopy/src/core.py
+++ b/tools/extopy/src/core.py
@@ -124,8 +124,11 @@ def diff(target: str, old: str, new: str) -> None:
         git.clone(repository_path, tempdir_path)
         git.checkout(new_revision)
 
-        old_target_path_rel = target_path_rel.with_stem(target_path.stem + '-old')
-        diff_target_path_rel = target_path_rel.with_stem(target_path.stem + '-diff')
+        old_target_path_rel = target_path_rel.with_name(target_path.stem + '-old' + target_path_rel.suffix)
+        diff_target_path_rel = target_path_rel.with_name(target_path.stem + '-diff' + target_path_rel.suffix)
+        # Python 3.9 以降なら次のように書ける
+        # old_target_path_rel = target_path_rel.with_stem(target_path.stem + '-old')
+        # diff_target_path_rel = target_path_rel.with_stem(target_path.stem + '-diff')
 
         git.show_and_save(target_path_rel, old_revision, old_target_path_rel)
 


### PR DESCRIPTION
## 詳細

- `extopy diff` が Python 3.8 で動作しなくなることがあった
- https://github.com/ykyki/extop-tex/pull/78 で追加した extopy のコードの中に, Python 3.9 以降で追加されたメソッドが使用されている箇所があった
- Python 3.8 で実行したい状況もあったため, このメソッドの使用を止めることにする

## したこと

- `with_stem()` メソッドを使っていた箇所を別にコードに差し替える
- 修正後, Python 3.8.12 で動作することを確認

## してないこと

- なし

## 連絡事項

- @CptHaus 動作確認お願いします🙇

## 参考資料

- なし

## Linked Issues

- Close https://github.com/ykyki/extop-tex/issues/79

## 確認事項

- [x] 変更箇所の動作確認・表示確認
- [x] レビュアー等の設定
- [x] このプルリクエストのプレビュー
