### PR TITLE
文書の表示レイアウトの修正

### DIFF
--- a/documents/config/layouts/develop.sty
+++ b/documents/config/layouts/develop.sty
@@ -24,12 +24,12 @@
 % \setlist{nolistsep}
 
 % 数式の上下のスペースの変更
-\AtBeginDocument{
-	\setlength{\abovedisplayskip}{3pt}
-	\setlength{\abovedisplayshortskip}{3pt}
-	\setlength{\belowdisplayskip}{2pt}
-	\setlength{\belowdisplayshortskip}{2pt}
-}
+% \AtBeginDocument{
+% 	\setlength{\abovedisplayskip}{3pt}
+% 	\setlength{\abovedisplayshortskip}{3pt}
+% 	\setlength{\belowdisplayskip}{2pt}
+% 	\setlength{\belowdisplayshortskip}{2pt}
+% }
 
 % 行間のスペース調整
 \renewcommand{\baselinestretch}{1.0}

--- a/documents/config/layouts/product.sty
+++ b/documents/config/layouts/product.sty
@@ -34,4 +34,4 @@
 }
 
 % 行間のスペース調整
-\renewcommand{\baselinestretch}{0.85}
+\renewcommand{\baselinestretch}{1.0}

--- a/documents/config/layouts/product.sty
+++ b/documents/config/layouts/product.sty
@@ -26,12 +26,12 @@
 \setlist{nosep}
 
 % 数式の上下のスペースの変更
-\AtBeginDocument{
-	\setlength{\abovedisplayskip}{3pt}
-	\setlength{\abovedisplayshortskip}{3pt}
-	\setlength{\belowdisplayskip}{2pt}
-	\setlength{\belowdisplayshortskip}{2pt}
-}
+% \AtBeginDocument{
+% 	\setlength{\abovedisplayskip}{3pt}
+% 	\setlength{\abovedisplayshortskip}{3pt}
+% 	\setlength{\belowdisplayskip}{2pt}
+% 	\setlength{\belowdisplayshortskip}{2pt}
+% }
 
 % 行間のスペース調整
 \renewcommand{\baselinestretch}{1.0}

--- a/documents/config/layouts/review.sty
+++ b/documents/config/layouts/review.sty
@@ -25,10 +25,10 @@
 
 \AtBeginDocument{
 	% 数式の上下のスペースの変更
-	\setlength{\abovedisplayskip}{3pt}
-	\setlength{\abovedisplayshortskip}{3pt}
-	\setlength{\belowdisplayskip}{2pt}
-	\setlength{\belowdisplayshortskip}{2pt}
+	% \setlength{\abovedisplayskip}{3pt}
+	% \setlength{\abovedisplayshortskip}{3pt}
+	% \setlength{\belowdisplayskip}{2pt}
+	% \setlength{\belowdisplayshortskip}{2pt}
 
 	% 強制的に two-sided レイアウトを無効化
 	\makeatletter


### PR DESCRIPTION
## 背景・意図

- PDFを表示したときに見づらいと感じた部分を修正する
- 文字密度が高くなりすぎているように感じたため、全体的にスペースを増やす

## したこと

- 行間のスペースを広げる

## してないこと

- 次の問題の解決:  #110

## 参考資料

- なし

## Linked Issues

## プルリク提出前: 確認事項

- [x] 変更範囲の再確認
- [x] Reviewers, Assignees, Labels, ...の項目設定
- [x] プルリクのタイトルがブランチ名のままになっていないか
- [x] このプルリクのプレビュー

## リバイズ進行状態

- [x] ビルドして表示変更を確認
