### PR TITLE
GitHub Actionsでビルドするzipファイルの内容修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,6 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: extop-tex-build-${{ github.run_number }}-${{ steps.vars.outputs.branch_name }}
-        path: ./temp/*.pdf
+        path: |
+          ./temp/
+          !./temp/.gitkeep


### PR DESCRIPTION
## 背景・意図

- GitHub Actions でビルドしたzipをファイルを解凍したときに、PDFファイルひとつのみ出てくる場合がある
- 常にフォルダとして解凍されるようにしたい

## したこと

- 定義: 〇〇空間
- 命題: 〇〇は□□で✗✗である
- 命題: 〇〇の特徴づけ
- コマンド〇〇の実装・挙動を修正
- 〇〇環境で動作することを確認

## してないこと

## 参考資料

## Linked Issues

## プルリク提出前: 確認事項

- [x] 変更範囲の再確認
- [x] Reviewers, Assignees, Labels, ...の項目設定
- [x] プルリクのタイトルがブランチ名のままになっていないか
- [x] このプルリクのプレビュー

## リバイズ進行状態

- なし
