### PR TITLE
compare.ymlの修正

### DIFF
--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -24,7 +24,7 @@ jobs:
         ls -l
         git status
     - name: build updated files
-      run: git diff --name-only origin/develop ./documents/catalog | xargs -P0 -L1 -I {} sh ./tools/build.sh {} review
+      run: git diff --name-only --diff-filter=M origin/develop ./documents/catalog | xargs -P0 -L1 -I {} sh ./tools/build.sh {} review
     - name: Set vars
       id: vars
       run: |


### PR DESCRIPTION
削除したファイルをビルドしようとしてエラーが出るバグの修正

## 背景・意図

- 削除したファイルもビルドしようとして失敗するバグ

## したこと

- git diff のオプションに --diff-filter=M (変更した差分のみ確認する) を追加

## プルリク提出前: 確認事項

- [x] 変更範囲の再確認
- [x] Reviewers, Assignees, Labels, ...の項目設定
- [x] プルリクのタイトルがブランチ名のままになっていないか
- [x] このプルリクのプレビュー

## リバイズ進行状態

- [ ] 文章の記述位置
- [ ] 数学的な内容
- [ ] 誤植や言葉使いなど文章の細部
- [ ] 出典の記載
- [ ] コマンドの使い方・コードフォーマット
